### PR TITLE
Fix phantom barrage, BP spec damage, and manual barrage speed

### DIFF
--- a/src/content/weapons/Blowpipe.ts
+++ b/src/content/weapons/Blowpipe.ts
@@ -6,6 +6,7 @@ import { ItemName } from "../../sdk/ItemName";
 import { Unit } from '../../sdk/Unit';
 import { AttackBonuses } from '../../sdk/gear/Weapon'
 import { AttackStyle, AttackStyleTypes } from '../../sdk/AttackStylesController';
+import { ProjectileOptions } from '../../sdk/weapons/Projectile';
 
 export class Blowpipe extends RangedWeapon {
   constructor() {
@@ -79,12 +80,14 @@ export class Blowpipe extends RangedWeapon {
     return 0.5
   }
 
-  specialAttack(from: Unit, to: Unit, bonuses: AttackBonuses = {}) {
+  specialAttack(from: Unit, to: Unit, bonuses: AttackBonuses = {}, options: ProjectileOptions = {}) {
     
     bonuses.isSpecialAttack = true;
+    // BP special attack takes an extra tick to land
+    options.reduceDelay = -1;
     super.attack(from, to, bonuses)
     
-    const healAttackerBy = Math.floor(this.damage / 2);
+    const healAttackerBy = Math.floor(this.damageRoll / 2);
     from.currentStats.hitpoint += healAttackerBy;
     from.currentStats.hitpoint = Math.min(from.currentStats.hitpoint, from.stats.hitpoint);
   }

--- a/src/sdk/Player.ts
+++ b/src/sdk/Player.ts
@@ -562,8 +562,9 @@ export class Player extends Unit {
     if (this.aggro) {
       this.setHasLOS()
       if (this.hasLOS && this.aggro && this.attackDelay <= 0 && this.aggro.isDying() === false) {
+        const attackDelay = this.attackSpeed
         if (this.attack()) {
-          this.attackDelay = this.attackSpeed
+          this.attackDelay = attackDelay
         }
       }
     }

--- a/src/sdk/Player.ts
+++ b/src/sdk/Player.ts
@@ -46,6 +46,7 @@ export class Player extends Unit {
   regenTimer: PlayerRegenTimer = new PlayerRegenTimer(this);
 
   autocastDelay = 1;
+  manualCastHasTarget = false;
 
   eats: Eating = new Eating();
   inventory: Item[];
@@ -353,6 +354,12 @@ export class Player extends Unit {
       this.autocastDelay = 1; // not sure if this is actually correct behavior but whatever
     }
 
+    if (this.manualSpellCastSelection && mob != null) {
+      this.manualCastHasTarget = true
+    } else {
+      this.manualCastHasTarget = false
+    }
+
     this.aggro = mob;
     this.seekingItem = null;
   }
@@ -565,7 +572,7 @@ export class Player extends Unit {
         if (this.attack()) {
           this.attackDelay = attackDelay
         }
-      } else if (this.manualSpellCastSelection && this.hasLOS && this.attackDelay <= 0 && this.aggro.dying == this.aggro.deathAnimationLength) {
+      } else if (this.manualSpellCastSelection && this.manualCastHasTarget && this.hasLOS && this.attackDelay <= 0 && this.aggro.dying == this.aggro.deathAnimationLength) {
         // Phantom/ghost barrage
         const attackDelay = this.attackSpeed
         if (this.attack()) {

--- a/src/sdk/Player.ts
+++ b/src/sdk/Player.ts
@@ -364,7 +364,6 @@ export class Player extends Unit {
   determineDestination() {
     if (this.aggro) {
       if (this.aggro.dying > -1) {
-        this.interruptCombat();
         this.destinationLocation = this.location
         return
       }
@@ -561,11 +560,22 @@ export class Player extends Unit {
 
     if (this.aggro) {
       this.setHasLOS()
-      if (this.hasLOS && this.aggro && this.attackDelay <= 0 && this.aggro.isDying() === false) {
+      if (this.hasLOS && this.attackDelay <= 0 && this.aggro.isDying() === false) {
         const attackDelay = this.attackSpeed
         if (this.attack()) {
           this.attackDelay = attackDelay
         }
+      } else if (this.manualSpellCastSelection && this.hasLOS && this.attackDelay <= 0 && this.aggro.dying == this.aggro.deathAnimationLength) {
+        // Phantom/ghost barrage
+        const attackDelay = this.attackSpeed
+        if (this.attack()) {
+          this.attackDelay = attackDelay
+        } 
+      }
+
+      // After allowing ghost barrage, unset aggro if enemy is dead 
+      if (this.aggro && this.aggro.isDying()) {
+        this.interruptCombat()
       }
     }
   }

--- a/src/sdk/Unit.ts
+++ b/src/sdk/Unit.ts
@@ -66,7 +66,7 @@ export interface UnitStats {
   range: number;
   magic: number;
   hitpoint: number;
-  prayer?: number;
+    prayer?: number;
 }
 
 export interface UnitBonuses {
@@ -119,6 +119,11 @@ export class Unit {
   setEffects: typeof SetEffect[] = [];
   autoRetaliate = false;
   spawnDelay = 0;
+  
+  
+  get deathAnimationLength() : number {
+    return 3
+  }
 
   get completeSetEffects(): SetEffect[] {
     return null;
@@ -450,7 +455,7 @@ export class Unit {
 
   dead () {
     this.perceivedLocation = this.location
-    this.dying = 3
+    this.dying = this.deathAnimationLength
   }
 
   detectDeath () {

--- a/src/sdk/Unit.ts
+++ b/src/sdk/Unit.ts
@@ -66,7 +66,7 @@ export interface UnitStats {
   range: number;
   magic: number;
   hitpoint: number;
-    prayer?: number;
+  prayer?: number;
 }
 
 export interface UnitBonuses {
@@ -119,7 +119,6 @@ export class Unit {
   setEffects: typeof SetEffect[] = [];
   autoRetaliate = false;
   spawnDelay = 0;
-  
   
   get deathAnimationLength() : number {
     return 3

--- a/src/sdk/gear/Weapon.ts
+++ b/src/sdk/gear/Weapon.ts
@@ -38,7 +38,6 @@ export class Weapon extends Equipment{
   damageRoll: number;
   lastHitHit = false;
   selected = false;
-  totalDamage = 0;
   inventorySprite: HTMLImageElement = ImageLoader.createImage(this.inventoryImage)
 
 
@@ -170,8 +169,6 @@ export class Weapon extends Equipment{
     
     // sanitize damage output
     this.damage = Math.floor(Math.max(Math.min(to.currentStats.hitpoint, this.damage, 100), 0));
-
-    this.totalDamage += this.damage;
 
     if (to.equipment.ring && to.equipment.ring.itemName === ItemName.RING_OF_SUFFERING_I && this.damage > 0){
       from.addProjectile(new Projectile(this, Math.floor(this.damage * 0.1) + 1, to, from, 'recoil', {reduceDelay: 15, hidden: true}))

--- a/src/sdk/gear/Weapon.ts
+++ b/src/sdk/gear/Weapon.ts
@@ -35,6 +35,7 @@ export interface AttackBonuses {
 
 export class Weapon extends Equipment{
   damage: number;
+  damageRoll: number;
   lastHitHit = false;
   selected = false;
   totalDamage = 0;
@@ -127,7 +128,8 @@ export class Weapon extends Equipment{
   }
 
   rollDamage(from: Unit, to: Unit, bonuses: AttackBonuses) {
-    this.damage = Math.floor(Math.min(this._rollAttack(from, to, bonuses), to.currentStats.hitpoint))
+    this.damageRoll = Math.floor(this._rollAttack(from, to, bonuses))
+    this.damage = Math.min(this.damageRoll, to.currentStats.hitpoint)
   }
 
 

--- a/src/sdk/weapons/BloodBarrageSpell.ts
+++ b/src/sdk/weapons/BloodBarrageSpell.ts
@@ -12,11 +12,9 @@ export class BloodBarrageSpell extends BarrageSpell {
 
   
   attack (from: Unit, to: Unit, bonuses: AttackBonuses = {}, options: ProjectileOptions = {}): boolean {
-    const startDamage = this.totalDamage;
     super.attack(from, to, bonuses, options)
-    const attackDamage = this.totalDamage - startDamage;
     if (from.currentStats.hitpoint < from.stats.hitpoint) {
-      from.currentStats.hitpoint += Math.floor(attackDamage * 0.25);
+      from.currentStats.hitpoint += Math.floor(this.damageRoll * 0.25);
       from.currentStats.hitpoint = Math.max(Math.min(from.stats.hitpoint, from.currentStats.hitpoint), 0);
     }
     return true;


### PR DESCRIPTION
Fixed a few miscellaneous bugs in a few different related areas:
- Changed blood barrage and blowpipe specs to heal based on the rolled damage, regardless of how much HP the enemies have. This is documented behavior for the toxic blowpipe and matches my empirical observations for how blood barrage works as well.
- Changed toxic blowpipe special attack to take an extra tick to land to match in-game behavior. (I'm not totally confident it's always one tick, but it's definitely always at least a tick so it's more right at least lol)
- Fixed attack delay for manually cast spells regardless of equipped weapon
- Add special case for phantom barrages

Closes #273 

Feel free to ask any questions if the reasoning for a particular change isn't clear.