### PR TITLE
Add inferno scout import and 1-tick practice tools/4-tick prayer visual

### DIFF
--- a/src/content/inferno/js/AttackCooldownOverlay.ts
+++ b/src/content/inferno/js/AttackCooldownOverlay.ts
@@ -1,0 +1,90 @@
+"use strict";
+
+import {
+  CollisionType,
+  Entity,
+  LineOfSightMask,
+  Location,
+  Player,
+  Region,
+} from "osrs-sdk";
+
+export class AttackCooldownOverlay extends Entity {
+  private player: Player;
+  private visibleAfterAttack = false;
+
+  constructor(region: Region, player: Player) {
+    super(region, { ...player.location });
+    this.player = player;
+  }
+
+  get collisionType() {
+    return CollisionType.NONE;
+  }
+
+  get lineOfSight() {
+    return LineOfSightMask.NONE;
+  }
+
+  get selectable() {
+    return false;
+  }
+
+  get size() {
+    return 1;
+  }
+
+  show() {
+    this.visibleAfterAttack = true;
+  }
+
+  sync() {
+    this.location = { ...this.player.location };
+
+    if (this.player.attackDelay <= 0) {
+      this.visibleAfterAttack = false;
+    }
+  }
+
+  getPerceivedLocation(tickPercent: number) {
+    return this.player.getPerceivedLocation(tickPercent);
+  }
+
+  getTrueLocation() {
+    return this.player.location;
+  }
+
+  draw() {
+    // Do not draw anything on the ground tile.
+  }
+
+  drawUILayer(
+    tickPercent: number,
+    offset: Location,
+    context: OffscreenCanvasRenderingContext2D,
+    scale: number,
+  ) {
+    if (!this.visibleAfterAttack || this.player.attackDelay <= 0) {
+      return;
+    }
+
+    const text = String(this.player.attackDelay);
+
+    context.save();
+    context.translate(offset.x, offset.y);
+
+    context.font = "bold 28px OSRS";
+    context.textAlign = "center";
+    context.lineWidth = 5;
+
+    // Black outline
+    context.strokeStyle = "black";
+    context.strokeText(text, 0, -scale * 2.6);
+
+    // Main number
+    context.fillStyle = this.player.attackDelay === 1 ? "#00ff00" : "#ffff00";
+    context.fillText(text, 0, -scale * 2.6);
+
+    context.restore();
+  }
+}

--- a/src/content/inferno/js/InfernoLoadout.ts
+++ b/src/content/inferno/js/InfernoLoadout.ts
@@ -300,7 +300,7 @@ export class InfernoLoadout {
         new SuperRestore(),
         new SuperRestore(),
         new BastionPotion(),
-        new StaminaPotion(),
+        new BastionPotion(),
         new SuperRestore(),
         new SuperRestore(),
       ],
@@ -467,26 +467,69 @@ export class InfernoLoadout {
     );
   }
 
-  setStats(player: Player) {
-    player.stats.prayer = 99;
-    player.currentStats.prayer = 99;
-    player.stats.defence = 99;
-    player.currentStats.defence = 99;
-    switch (this.loadoutType) {
-      case "zerker":
-        player.stats.prayer = 52;
-        player.currentStats.prayer = 52;
-        player.stats.defence = 45;
-        player.currentStats.defence = 45;
-        break;
-      case "pure":
-        player.stats.prayer = 52;
-        player.currentStats.prayer = 52;
-        player.stats.defence = 1;
-        player.currentStats.defence = 1;
-        break;
+setStats(player: Player) {
+  const savedStats = JSON.parse(
+    localStorage.getItem("inferno_custom_stats_v1") || "{}",
+  );
+
+  const getSavedStat = (name: string, fallback: number) => {
+    const value = Number(savedStats[name]);
+
+    if (!Number.isFinite(value)) {
+      return fallback;
     }
+
+    if (value < 1) {
+      return 1;
+    }
+
+    if (value > 99) {
+      return 99;
+    }
+
+    return value;
+  };
+
+  const setPlayerStat = (name: string, value: number) => {
+    (player.stats as any)[name] = value;
+    (player.currentStats as any)[name] = value;
+  };
+
+  if (savedStats.enabled === true) {
+    setPlayerStat("attack", getSavedStat("attack", 99));
+    setPlayerStat("strength", getSavedStat("strength", 99));
+    setPlayerStat("defence", getSavedStat("defence", 99));
+    setPlayerStat("range", getSavedStat("range", 99));
+    setPlayerStat("magic", getSavedStat("magic", 99));
+    setPlayerStat("prayer", getSavedStat("prayer", 99));
+    setPlayerStat("hitpoint", getSavedStat("hitpoint", 99));
+    setPlayerStat("agility", getSavedStat("agility", 99));
+
+    return;
   }
+
+  // Default stats if custom stats are turned off
+  setPlayerStat("attack", 99);
+  setPlayerStat("strength", 99);
+  setPlayerStat("defence", 99);
+  setPlayerStat("range", 99);
+  setPlayerStat("magic", 99);
+  setPlayerStat("prayer", 99);
+  setPlayerStat("hitpoint", 99);
+  setPlayerStat("agility", 99);
+
+  switch (this.loadoutType) {
+    case "zerker":
+      setPlayerStat("prayer", 52);
+      setPlayerStat("defence", 45);
+      break;
+
+    case "pure":
+      setPlayerStat("prayer", 52);
+      setPlayerStat("defence", 1);
+      break;
+  }
+}
 
   getLoadout(): UnitOptions {
     let loadout: UnitOptions;

--- a/src/content/inferno/js/InfernoPillar.ts
+++ b/src/content/inferno/js/InfernoPillar.ts
@@ -4,6 +4,8 @@ import { Entity, Projectile, UnitBonuses, Region, Settings, DelayedAction, Model
 
 import { filter, remove } from "lodash";
 
+import { InfernoPillarModel } from "./InfernoPillarModel";
+
 const MissSplat = Assets.getAssetUrl("assets/images/hitsplats/miss.png");
 const DamageSplat = Assets.getAssetUrl("assets/images/hitsplats/damage.png");
 
@@ -216,7 +218,11 @@ export class InfernoPillar extends Entity {
     }
   }
 
-  create3dModel(): Model {
-    return BasicModel.forRenderable(this);
-  }
+create3dModel(): Model {
+  return BasicModel.forRenderable(this);
+}
+
+  /*create3dModel(): Model {
+  return new InfernoPillarModel();
+}*/
 }

--- a/src/content/inferno/js/InfernoPillarModel.ts
+++ b/src/content/inferno/js/InfernoPillarModel.ts
@@ -1,0 +1,96 @@
+import * as THREE from "three";
+import { Model } from "osrs-sdk";
+
+export class InfernoPillarModel implements Model {
+  private group = new THREE.Group();
+
+  constructor() {
+    const blackRock = new THREE.MeshStandardMaterial({ color: 0x171717 });
+    const darkRock = new THREE.MeshStandardMaterial({ color: 0x24201d });
+    const redRock = new THREE.MeshStandardMaterial({ color: 0x5a1b10 });
+    const lavaRock = new THREE.MeshStandardMaterial({ color: 0x7a2a12 });
+
+    // Small broken base, not a full chunky square
+    this.addRock(1.9, 0.35, 1.8, 0, 0.15, 0, lavaRock, 0.2);
+    this.addRock(1.6, 0.35, 1.5, -0.25, 0.45, 0.15, redRock, -0.4);
+
+    // Main thin pillar body
+    this.addRock(1.35, 1.3, 1.25, 0.05, 1.15, 0, darkRock, 0.1);
+    this.addRock(1.15, 1.35, 1.1, -0.1, 2.15, 0.05, blackRock, -0.35);
+    this.addRock(1.25, 1.25, 1.05, 0.1, 3.15, -0.05, blackRock, 0.45);
+
+    // Top wider jagged bit
+    this.addRock(1.8, 0.55, 1.5, -0.05, 4.05, 0, blackRock, 0.2);
+    this.addRock(1.45, 0.45, 1.35, 0.15, 4.45, -0.05, blackRock, -0.25);
+
+    // Small side lumps so it is not perfectly straight
+    this.addRock(0.55, 0.7, 0.7, -0.85, 1.45, 0.1, redRock, 0.4);
+    this.addRock(0.5, 0.65, 0.65, 0.8, 2.5, -0.05, darkRock, -0.5);
+    this.addRock(0.55, 0.5, 0.7, -0.75, 3.4, 0.15, blackRock, 0.1);
+  }
+
+  private addRock(
+    width: number,
+    height: number,
+    depth: number,
+    x: number,
+    y: number,
+    z: number,
+    material: THREE.MeshStandardMaterial,
+    rotationY = 0,
+  ) {
+    // Low segment cylinder gives a rough OSRS-style rocky shape instead of a cube
+    const geometry = new THREE.CylinderGeometry(
+      width / 2,
+      depth / 2,
+      height,
+      7,
+    );
+
+    const rock = new THREE.Mesh(geometry, material);
+    rock.position.set(x, y, z);
+    rock.rotation.y = rotationY;
+    rock.rotation.x = 0.05;
+    rock.rotation.z = -0.03;
+    rock.castShadow = true;
+    rock.receiveShadow = true;
+
+    this.group.add(rock);
+  }
+
+  draw(
+    scene: THREE.Scene,
+    clockDelta: number,
+    tickPercent: number,
+    location: any,
+    rotation: number,
+    pitch: number,
+    visible: boolean,
+  ) {
+    if (this.group.parent !== scene) {
+      scene.add(this.group);
+    }
+
+    this.group.visible = visible;
+
+    this.group.position.x = location.x + 1.5;
+    this.group.position.y = location.z - 0.8;
+    this.group.position.z = location.y - 1.5;
+
+    this.group.rotation.y = rotation;
+  }
+
+  destroy(scene: THREE.Scene) {
+    if (this.group.parent === scene) {
+      scene.remove(this.group);
+    }
+  }
+
+  getWorldPosition(): THREE.Vector3 {
+    return this.group.getWorldPosition(new THREE.Vector3());
+  }
+
+  async preload() {
+    return;
+  }
+}

--- a/src/content/inferno/js/InfernoRegion.ts
+++ b/src/content/inferno/js/InfernoRegion.ts
@@ -1,5 +1,5 @@
 "use strict";
-import { BrowserUtils, CardinalDirection, ControlPanelController, Entity, EntityNames, ImageLoader, InvisibleMovementBlocker, Location, Mob, Player, Region, Settings, TileMarker, Trainer, Viewport } from "osrs-sdk";
+import { BrowserUtils, ItemName, CardinalDirection, ControlPanelController, Entity, EntityNames, ImageLoader, InvisibleMovementBlocker, Location, Mob, Player, Region, Settings, TileMarker, Trainer, Viewport } from "osrs-sdk";
 
 import InfernoMapImage from "../assets/images/map.png";
 
@@ -21,11 +21,20 @@ import { Wall } from "./Wall";
 import { ZukShield, type ShieldDirection } from "./ZukShield";
 
 import SidebarContent from "../sidebar.html";
+import { AttackCooldownOverlay } from "./AttackCooldownOverlay";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+
+
 export class InfernoRegion extends Region {
   wave: number;
+  fourTickCycleIndex: number = 0;
+  fourTickBoxes: HTMLDivElement[] = [];
+  fourTickContainer: HTMLDivElement | null = null;
+  fourTickCycleEnabled: boolean = true;
+  fourTickSettingsToggle: HTMLDivElement | null = null;
+  private attackCooldownOverlay?: AttackCooldownOverlay;
   mapImage: HTMLImageElement = ImageLoader.createImage(InfernoMapImage);
 
   // Wave progression properties
@@ -234,6 +243,34 @@ export class InfernoRegion extends Region {
     });
   }
 
+  isSettingsTabOpen() {
+  const selectedControl = ControlPanelController.controller.selectedControl as any;
+  const controls = ControlPanelController.controls as any;
+
+  const possibleSettingsControls = [
+    controls.SETTINGS,
+    controls.OPTIONS,
+    controls.SETTING,
+    controls.CONFIG,
+  ].filter(Boolean);
+
+  const selectedControlText = [
+    selectedControl?.constructor?.name,
+    selectedControl?.name,
+    selectedControl?.label,
+    selectedControl?.id,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  return (
+    possibleSettingsControls.includes(selectedControl) ||
+    selectedControlText.includes("setting") ||
+    selectedControlText.includes("option")
+  );
+}
+
   initializeDisplaySetTimerToggle() {
     const displaySetTimerCheckbox = document.getElementById("displaySetTimer") as HTMLInputElement;
     displaySetTimerCheckbox.checked = InfernoSettings.displaySetTimer === true;
@@ -243,7 +280,468 @@ export class InfernoRegion extends Region {
     });
   }
 
-  initialiseRegion() {
+  initializeFourTickCycle() {
+  // Remove old overlay if it somehow already exists
+  if (this.fourTickContainer) {
+    this.fourTickContainer.remove();
+    this.fourTickContainer = null;
+  }
+  if (this.fourTickSettingsToggle) {
+  this.fourTickSettingsToggle.remove();
+  this.fourTickSettingsToggle = null;
+}
+
+const savedFourTickSetting = localStorage.getItem(
+  "inferno_four_tick_cycle_enabled",
+);
+
+this.fourTickCycleEnabled =
+  savedFourTickSetting === null ? true : savedFourTickSetting === "true";
+
+  const container = document.createElement("div");
+  container.id = "floatingFourTickCycle";
+  container.style.position = "fixed";
+  container.style.right = "320px";
+  container.style.bottom = "400px";
+  container.style.zIndex = "9999";
+  container.style.display = "flex";
+  container.style.gap = "6px";
+  container.style.padding = "6px";
+  container.style.pointerEvents = "none";
+
+  const boxes: HTMLDivElement[] = [];
+
+  for (let i = 0; i < 4; i++) {
+    const box = document.createElement("div");
+    box.innerText = String(i + 1);
+    box.style.width = "38px";
+    box.style.height = "38px";
+    box.style.lineHeight = "38px";
+    box.style.textAlign = "center";
+    box.style.fontWeight = "bold";
+    box.style.fontSize = "20px";
+    box.style.border = "2px solid #4a90e2";
+    box.style.borderRadius = "4px";
+    box.style.background = "#1e2b3a";
+    box.style.color = "white";
+    box.style.boxSizing = "border-box";
+    box.style.fontFamily = "sans-serif";
+
+    boxes.push(box);
+    container.appendChild(box);
+  }
+
+  document.body.appendChild(container);
+
+  this.fourTickContainer = container;
+  this.fourTickBoxes = boxes;
+
+  const settingsToggle = document.createElement("div");
+settingsToggle.id = "fourTickSettingsToggle";
+settingsToggle.style.position = "fixed";
+settingsToggle.style.right = "345px";
+settingsToggle.style.bottom = "405px";
+settingsToggle.style.zIndex = "10000";
+settingsToggle.style.display = "none";
+settingsToggle.style.alignItems = "center";
+settingsToggle.style.gap = "6px";
+settingsToggle.style.color = "yellow";
+settingsToggle.style.fontWeight = "";
+settingsToggle.style.fontSize = "24px";
+settingsToggle.style.pointerEvents = "auto";
+settingsToggle.style.userSelect = "none";
+
+const checkbox = document.createElement("input");
+checkbox.type = "checkbox";
+checkbox.checked = this.fourTickCycleEnabled;
+checkbox.style.cursor = "pointer";
+
+const label = document.createElement("span");
+label.innerText = "4-Tick Prayer Visual";
+
+checkbox.addEventListener("change", () => {
+  this.fourTickCycleEnabled = checkbox.checked;
+
+  localStorage.setItem(
+    "inferno_four_tick_cycle_enabled",
+    String(this.fourTickCycleEnabled),
+  );
+
+  this.updateFourTickCycleDisplay();
+});
+
+settingsToggle.addEventListener("mousedown", (event) => {
+  event.stopPropagation();
+});
+
+settingsToggle.addEventListener("click", (event) => {
+  event.stopPropagation();
+});
+
+settingsToggle.appendChild(checkbox);
+settingsToggle.appendChild(label);
+
+document.body.appendChild(settingsToggle);
+
+this.fourTickSettingsToggle = settingsToggle;
+
+  this.updateFourTickCycleDisplay();
+}
+
+updateFourTickCycleDisplay() {
+  const isPrayerTabOpen =
+    ControlPanelController.controller.selectedControl ===
+    ControlPanelController.controls.PRAYER;
+
+  const isSettingsTabOpen = this.isSettingsTabOpen();
+
+  if (this.fourTickSettingsToggle) {
+    this.fourTickSettingsToggle.style.display = isSettingsTabOpen
+      ? "flex"
+      : "none";
+  }
+
+  const shouldShowPrayerVisual =
+    this.fourTickCycleEnabled && isPrayerTabOpen;
+
+  if (this.fourTickContainer) {
+    this.fourTickContainer.style.display = shouldShowPrayerVisual
+      ? "flex"
+      : "none";
+  }
+
+  if (!shouldShowPrayerVisual) {
+    return;
+  }
+
+  this.fourTickBoxes.forEach((box, index) => {
+    if (index === this.fourTickCycleIndex) {
+      if (index === 0) {
+        box.style.background = "#7dff7d";
+        box.style.color = "black";
+        box.style.borderColor = "#ffffff";
+      } else {
+        box.style.background = "#58c4ff";
+        box.style.color = "black";
+        box.style.borderColor = "#ffffff";
+      }
+    } else {
+      box.style.background = "#1e2b3a";
+      box.style.color = "white";
+      box.style.borderColor = "#4a90e2";
+    }
+  });
+}
+  
+initializeInfernoScouterCodeImport() {
+  const input = document.getElementById(
+    "infernoScouterCode",
+  ) as HTMLInputElement;
+
+  const button = document.getElementById(
+    "loadInfernoScouterCode",
+  ) as HTMLButtonElement;
+
+  const message = document.getElementById(
+    "infernoScouterCodeMessage",
+  ) as HTMLElement;
+
+  if (!input || !button) {
+    return;
+  }
+
+  const trainerSpawnSlots = [
+    [1, 5],   // slot 1
+    [22, 5],  // slot 2
+    [3, 11],  // slot 3
+    [23, 12], // slot 4
+    [16, 17], // slot 5
+    [5, 23],  // slot 6
+    [23, 25], // slot 7
+    [1, 28],  // slot 8
+    [15, 28], // slot 9
+  ];
+
+  const parseCode = (rawCode: string) => {
+    let code = rawCode.trim();
+
+    // If the user pasted "[oMRoBXoYo]", use the part inside brackets.
+    const bracketMatch = code.match(/\[([^\]]+)\]/);
+    if (bracketMatch) {
+      code = bracketMatch[1];
+    }
+
+    // Remove spaces, brackets, and NPC-index rank numbers.
+    // Example: "M1oR2ooooo" becomes "MoRoooooo".
+    code = code
+      .toUpperCase()
+      .replace(/[\[\]\s]/g, "")
+      .replace(/[0-9]/g, "");
+
+    if (code.length !== 9) {
+      throw new Error(
+        `Invalid code length. Expected 9 spawn letters, got ${code.length}.`,
+      );
+    }
+
+    if (!/^[OYBRXM]{9}$/.test(code)) {
+      throw new Error(
+        "Invalid code. Only use o, Y, B, R, X, and M.",
+      );
+    }
+
+    return code;
+  };
+
+  const buildUrlFromCode = (rawCode: string) => {
+    const code = parseCode(rawCode);
+
+    const mobs = {
+      mager: [] as number[][],
+      ranger: [] as number[][],
+      melee: [] as number[][],
+      blob: [] as number[][],
+      bat: [] as number[][],
+    };
+
+    for (let i = 0; i < code.length; i++) {
+      const letter = code[i];
+      const spawn = trainerSpawnSlots[i];
+
+      switch (letter) {
+        case "M":
+          mobs.mager.push(spawn);
+          break;
+
+        case "R":
+          mobs.ranger.push(spawn);
+          break;
+
+        case "X":
+          mobs.melee.push(spawn);
+          break;
+
+        case "B":
+          mobs.blob.push(spawn);
+          break;
+
+        case "Y":
+          mobs.bat.push(spawn);
+          break;
+
+        case "O":
+          break;
+      }
+    }
+
+    return (
+      "/?wave=0" +
+      `&mager=${encodeURIComponent(JSON.stringify(mobs.mager))}` +
+      `&ranger=${encodeURIComponent(JSON.stringify(mobs.ranger))}` +
+      `&melee=${encodeURIComponent(JSON.stringify(mobs.melee))}` +
+      `&blob=${encodeURIComponent(JSON.stringify(mobs.blob))}` +
+      `&bat=${encodeURIComponent(JSON.stringify(mobs.bat))}` +
+      "&copyable"
+    );
+  };
+
+  const loadCode = () => {
+    try {
+      const url = buildUrlFromCode(input.value);
+      window.location.href = url;
+    } catch (error) {
+      if (message) {
+        message.innerText =
+          error instanceof Error ? error.message : "Invalid Inferno Scouter code.";
+        message.style.color = "red";
+      }
+    }
+  };
+
+  button.addEventListener("click", loadCode);
+
+  input.addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+      loadCode();
+    }
+  });
+}
+
+initializeOneTickTraining() {
+  const scenarioSelect = document.getElementById(
+    "oneTickScenario",
+  ) as HTMLSelectElement;
+
+  const loadButton = document.getElementById(
+    "loadOneTickScenario",
+  ) as HTMLButtonElement;
+
+  if (!scenarioSelect || !loadButton) {
+    return;
+  }
+
+  // These coordinates use the trainer's existing custom-wave coordinate system.
+  // importSpawn() later adds +11 and +14 to these values.
+  const stackTile = [16, 17];
+  const sideTileOne = [15, 17];
+  const sideTileTwo = [17, 17];
+
+  const scenarios: Record<
+    string,
+    {
+      mager: number[][];
+      ranger: number[][];
+      melee: number[][];
+      blob: number[][];
+      bat: number[][];
+    }
+  > = {
+    mage_ranger: {
+      mager: [stackTile],
+      ranger: [stackTile],
+      melee: [],
+      blob: [],
+      bat: [],
+    },
+
+    mage_melee: {
+      mager: [stackTile],
+      ranger: [],
+      melee: [stackTile],
+      blob: [],
+      bat: [],
+    },
+
+    ranger_melee: {
+      mager: [],
+      ranger: [stackTile],
+      melee: [stackTile],
+      blob: [],
+      bat: [],
+    },
+
+    mage_ranger_blob: {
+      mager: [stackTile],
+      ranger: [stackTile],
+      melee: [],
+      blob: [sideTileOne],
+      bat: [],
+    },
+
+    two_blobs_ranger: {
+      mager: [],
+      ranger: [stackTile],
+      melee: [],
+      blob: [sideTileOne, sideTileTwo],
+      bat: [],
+    },
+
+    two_blobs_mager: {
+      mager: [stackTile],
+      ranger: [],
+      melee: [],
+      blob: [sideTileOne, sideTileTwo],
+      bat: [],
+    },
+
+    mage_ranger_melee: {
+      mager: [stackTile],
+      ranger: [stackTile],
+      melee: [stackTile],
+      blob: [],
+      bat: [],
+    },
+
+    blob_ranger_melee: {
+      mager: [],
+      ranger: [stackTile],
+      melee: [stackTile],
+      blob: [sideTileOne],
+      bat: [],
+    },
+  };
+
+  const buildScenarioUrl = (scenarioKey: string) => {
+    const scenario = scenarios[scenarioKey];
+
+    if (!scenario) {
+      return "/?wave=0";
+    }
+
+    return (
+      "/?wave=0" +
+      `&mager=${encodeURIComponent(JSON.stringify(scenario.mager))}` +
+      `&ranger=${encodeURIComponent(JSON.stringify(scenario.ranger))}` +
+      `&melee=${encodeURIComponent(JSON.stringify(scenario.melee))}` +
+      `&blob=${encodeURIComponent(JSON.stringify(scenario.blob))}` +
+      `&bat=${encodeURIComponent(JSON.stringify(scenario.bat))}` +
+      "&copyable&autoplay=true"
+    );
+  };
+
+  loadButton.addEventListener("click", () => {
+    window.location.href = buildScenarioUrl(scenarioSelect.value);
+  });
+}
+
+startAutoplayIfRequested() {
+  const shouldAutoplay = BrowserUtils.getQueryVar("autoplay") === "true";
+
+  if (!shouldAutoplay) {
+    return;
+  }
+
+  // Wait until the trainer has fully rendered and the play button exists.
+  setTimeout(() => {
+    const pauseResumeButton = document.getElementById(
+      "pauseResumeLink",
+    ) as HTMLButtonElement;
+
+    if (!pauseResumeButton) {
+      return;
+    }
+
+    // Only start if it is actually paused.
+    if (this.world.isPaused) {
+      pauseResumeButton.click();
+    }
+  }, 1000);
+}
+
+initializeCustomStatsPanel() {
+  const savedStats = JSON.parse(
+    localStorage.getItem("inferno_custom_stats_v1") || "{}",
+  );
+
+  const useCustomStats = document.getElementById(
+    "useCustomStats",
+  ) as HTMLInputElement;
+
+  if (!useCustomStats) {
+    return;
+  }
+
+  useCustomStats.checked = savedStats.enabled === true;
+
+  const setInputValue = (id: string, value: number) => {
+    const input = document.getElementById(id) as HTMLInputElement;
+
+    if (input) {
+      input.value = String(value);
+    }
+  };
+
+  setInputValue("customAttack", savedStats.attack ?? 90);
+  setInputValue("customStrength", savedStats.strength ?? 99);
+  setInputValue("customDefence", savedStats.defence ?? 99);
+  setInputValue("customRange", savedStats.range ?? 99);
+  setInputValue("customMagic", savedStats.magic ?? 94);
+  setInputValue("customPrayer", savedStats.prayer ?? 80);
+  setInputValue("customHitpoint", savedStats.hitpoint ?? 99);
+  setInputValue("customAgility", savedStats.agility ?? 71);
+}
+
+initialiseRegion() {
     const waveInput: HTMLInputElement = document.getElementById("waveinput") as HTMLInputElement;
 
 
@@ -341,6 +839,10 @@ export class InfernoRegion extends Region {
     this.initializeWaveProgressionToggle();
     this.initializeSpawnIndicatorsToggle();
     this.initializeDisplaySetTimerToggle();
+    this.initializeFourTickCycle();
+    this.initializeInfernoScouterCodeImport();
+    this.initializeOneTickTraining();
+    this.initializeCustomStatsPanel();
     this.wave = parseInt(BrowserUtils.getQueryVar("wave"));
 
     if (isNaN(this.wave)) {
@@ -356,6 +858,25 @@ export class InfernoRegion extends Region {
     const loadout = new InfernoLoadout(this.wave, loadoutType, onTask);
     loadout.setStats(player); // flip this around one day
     player.setUnitOptions(loadout.getLoadout());
+
+    this.attackCooldownOverlay = new AttackCooldownOverlay(this, player);
+this.addEntity(this.attackCooldownOverlay);
+
+const originalDidAttack = player.didAttack.bind(player);
+
+player.didAttack = () => {
+  originalDidAttack();
+
+  const weaponName = player.equipment.weapon?.itemName;
+
+  const isBowAttack =
+    weaponName === ItemName.BOWFA ||
+    weaponName === ItemName.TWISTED_BOW;
+
+  if (isBowAttack) {
+    this.attackCooldownOverlay?.show();
+  }
+};
 
     if (this.wave < 67 || this.wave >= 70) {
       // Add pillars
@@ -593,9 +1114,11 @@ export class InfernoRegion extends Region {
     }
 
     player.perceivedLocation = player.location;
-    player.destinationLocation = player.location;
+player.destinationLocation = player.location;
 
-    return { player };
+this.startAutoplayIfRequested();
+
+return { player };
   }
 
   drawWorldBackground(context: OffscreenCanvasRenderingContext2D, scale: number) {
@@ -658,9 +1181,15 @@ export class InfernoRegion extends Region {
   }
 
   postTick() {
-    super.postTick();
-    this.handleWaveProgression();
-  }
+  super.postTick();
+
+  this.attackCooldownOverlay?.sync();
+
+  this.fourTickCycleIndex = (this.fourTickCycleIndex + 1) % 4;
+  this.updateFourTickCycleDisplay();
+
+  this.handleWaveProgression();
+}
 
   private handleWaveProgression() {
     // Only enable wave progression for waves 1-69 and if the setting is enabled

--- a/src/content/inferno/js/mobs/JalZek.ts
+++ b/src/content/inferno/js/mobs/JalZek.ts
@@ -61,7 +61,7 @@ export class JalZek extends Mob {
 
   setStats() {
     const region = this.region as InfernoRegion;
-    this.shouldRespawnMobs = region.wave >= 69;
+    this.shouldRespawnMobs = region.wave === 69;
 
     this.stunned = 1;
 

--- a/src/content/inferno/sidebar.html
+++ b/src/content/inferno/sidebar.html
@@ -11,6 +11,7 @@
   >
     New Wave
   </button>
+  <button id="exportCustomWave">Play Wave</button>
   <a id="replayLink">Replay Wave</a>
   <button id="pauseResumeLink">Pause Wave</button>
 
@@ -24,6 +25,93 @@
     <option value="pure">Pure</option>
     <option value="max_melee">Max Melee (WIP)</option>
   </select>
+
+  <hr />
+
+<div style="padding: 8px;">
+  <h3>Custom Stats</h3>
+
+  <label>
+    <input type="checkbox" id="useCustomStats" />
+    Use custom stats
+  </label>
+
+  <div style="display: grid; grid-template-columns: 1fr 70px; gap: 6px; margin-top: 8px;">
+    <label for="customAttack">Attack</label>
+    <input id="customAttack" type="number" min="1" max="99" value="90" />
+
+    <label for="customStrength">Strength</label>
+    <input id="customStrength" type="number" min="1" max="99" value="99" />
+
+    <label for="customDefence">Defence</label>
+    <input id="customDefence" type="number" min="1" max="99" value="99" />
+
+    <label for="customRange">Range</label>
+    <input id="customRange" type="number" min="1" max="99" value="99" />
+
+    <label for="customMagic">Magic</label>
+    <input id="customMagic" type="number" min="1" max="99" value="94" />
+
+    <label for="customPrayer">Prayer</label>
+    <input id="customPrayer" type="number" min="1" max="99" value="80" />
+
+    <label for="customHitpoint">Hitpoint</label>
+    <input id="customHitpoint" type="number" min="1" max="99" value="99" />
+
+    <label for="customAgility">Agility</label>
+    <input id="customAgility" type="number" min="1" max="99" value="71" />
+  </div>
+
+  <button
+    id="saveCustomStats"
+    style="margin-top: 8px; width: 100%;"
+    onclick="
+      (function () {
+        const clamp = function (id) {
+          const input = document.getElementById(id);
+          const value = Number(input.value);
+
+          if (!Number.isFinite(value)) {
+            return 99;
+          }
+
+          if (value < 1) {
+            return 1;
+          }
+
+          if (value > 99) {
+            return 99;
+          }
+
+          return value;
+        };
+
+        const stats = {
+          enabled: document.getElementById('useCustomStats').checked,
+          attack: clamp('customAttack'),
+          strength: clamp('customStrength'),
+          defence: clamp('customDefence'),
+          range: clamp('customRange'),
+          magic: clamp('customMagic'),
+          prayer: clamp('customPrayer'),
+          hitpoint: clamp('customHitpoint'),
+          agility: clamp('customAgility')
+        };
+
+        localStorage.setItem('inferno_custom_stats_v1', JSON.stringify(stats));
+
+        alert('Custom stats saved. The wave will now reload.');
+        window.location.reload();
+      })();
+    "
+  >
+    Save custom stats
+  </button>
+
+  <p style="font-size: 12px; margin-top: 6px;">
+    Save, then reload the wave for the stats to apply.
+  </p>
+</div>
 
   <select name="shieldDirection" id="shieldDirection">
     <option value="random">Random Shield Direction</option>
@@ -81,16 +169,53 @@
     <input type="checkbox" id="displaySetTimer" name="displaySetTimer">
     <label for="displaySetTimer">Display Set Timer Below Zuk</label>
   </div>
-  
+  <hr />
+
+<div style="padding: 8px;">
+  <h3>Inferno Scouter Code</h3>
+
+  <input
+    id="infernoScouterCode"
+    type="text"
+    placeholder="Paste code e.g. oMRoBXoYo"
+    style="width: 100%; box-sizing: border-box;"
+  />
+
+  <button id="loadInfernoScouterCode" style="margin-top: 6px; width: 100%;">
+    Load Scouter Code
+  </button>
+  <button id="exportCustomWave">Play Wave</button>
+  <p id="infernoScouterCodeMessage" style="font-size: 12px; margin-top: 6px;"></p>
+</div>
+
+<hr />
+
+<div style="padding: 8px;">
+  <h3>1-Tick Training</h3>
+
+  <select id="oneTickScenario" style="width: 100%; box-sizing: border-box;">
+    <option value="mage_ranger">Mager + Ranger stack</option>
+    <option value="mage_melee">Mager + Melee stack</option>
+    <option value="ranger_melee">Ranger + Melee stack</option>
+    <option value="mage_ranger_blob">Mager + Ranger + Blob</option>
+    <option value="two_blobs_ranger">2 Blobs + Ranger</option>
+    <option value="two_blobs_mager">2 Blobs + Mager</option>
+    <option value="mage_ranger_melee">Mager + Ranger + Melee</option>
+    <option value="blob_ranger_melee">Blob + Ranger + Melee</option>
+  </select>
+
+  <button id="loadOneTickScenario" style="margin-top: 6px; width: 100%;">
+    Load 1-Tick Scenario
+  </button>
+
+  <p style="font-size: 12px; margin-top: 6px;">
+    Loads a custom stack for practising 1-tick alternate prayer flicking.
+  </p>
+</div>
+
   <a href="/?wave=0">Custom Mob Mode</a>
   <button id="exportCustomWave">Play/Export Wave</button>
   <button id="editWave">Edit Wave</button>
   <hr />
-
-  <a href="https://github.com/OldSchoolSDK/Engine" target="_blank"
-    >Explore Source on GitHub</a
-  >
-  <a href="https://discord.gg/Z3ZyY7Yzt5" target="_blank"
-    >Join Our Discord</a
   >
   <a href="https://oldschool.runescape.wiki/w/Inferno">Mob Explanations</a>


### PR DESCRIPTION
## Summary

Adds several Inferno practice tools:

* Inferno Scout code import
* Automatic mob placement from imported scout codes
* Custom stats support
* 4-tick visual prayer indicator, shown only when the prayer book is open
* Additional practice support for wave solving and 1-tick alternating

## Testing

Tested locally by:

* Loading the trainer
* Importing Inferno Scout codes
* Checking that mobs spawn in the expected positions
* Confirming the prayer overlay only appears when the prayer book is open
* Checking custom stats behaviour after refreshing
